### PR TITLE
Not break munging

### DIFF
--- a/mapall.py
+++ b/mapall.py
@@ -93,9 +93,12 @@ class Dot(object):
         """ Munge name to be dottable """
         if not s:
             s = self.name
-        s = s.replace('-', '_')
-        s = s.replace("'", '"')
-        return s
+        try:
+            s = s.replace('-', '_')
+            s = s.replace("'", '"')
+            return s
+        except Exception as e:
+            return 'NoName'
 
     ##########################################################################
     def partOfInstance(self, instid):

--- a/mapall.py
+++ b/mapall.py
@@ -97,7 +97,7 @@ class Dot(object):
             s = s.replace('-', '_')
             s = s.replace("'", '"')
             return s
-        except Exception as e:
+        except AttributeError as e:
             return 'NoName'
 
     ##########################################################################


### PR DESCRIPTION
I still don't know why but a None object ended up in the `s` variable
breaking the `replace` function:

```
AttributeError: 'NoneType' object has no attribute 'replace'
```

Due to lack of complete understanding of the tool and my debug-foo not
issuing any results I'm just hotfixing it with a try/catch.

Please feel free to use a proper fixing.