### PR TITLE
Honor the AWS_DEFAULT_REGION environment variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,10 @@ The program will write the results of the aws query to a .cache
 directory and use that unless you specify --nocache. Cacheing is
 much faster than querying AWS everytime but obviously won't react
 to changes that are made.
+
+Region
+------
+You must indicate a region for the queries.  This can be through the
+--region CLI option, or the AWS_DEFAULT_REGION environment variable.
+If both are set, the CLI opton takes precedence.
+

--- a/mapall.py
+++ b/mapall.py
@@ -1315,8 +1315,16 @@ def parseArgs():
         help="Print some details")
 
     requiredNamed = parser.add_argument_group('required named arguments')
+
+    if 'AWS_DEFAULT_REGION' in os.environ:
+        default_region=os.environ['AWS_DEFAULT_REGION']
+        region_required = False
+    else:
+        default_region=False
+        region_required = True
+
     requiredNamed.add_argument(
-        '--region', default=None, required=True,
+        '--region', default=default_region, required=region_required,
         help="ec2 region")
 
     args = parser.parse_args()


### PR DESCRIPTION
Make use of the AWS_DEFAULT_REGION environment variable, if set.