### PR TITLE
Quote nodes to fix dot syntax error

### DIFF
--- a/mapall.py
+++ b/mapall.py
@@ -96,7 +96,7 @@ class Dot(object):
         try:
             s = s.replace('-', '_')
             s = s.replace("'", '"')
-            return s
+            return '"' + s + '"'
         except AttributeError as e:
             return 'NoName'
 


### PR DESCRIPTION
Some nodes contain dots which make `dot` error. Quoting all nodes seems to work.